### PR TITLE
Improve API

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -15,5 +15,10 @@
   <module name="TreeWalker">
     <module name="OuterTypeFilename" />
     <module name="EmptyLineSeparator" />
+    <module name="Regexp">
+      <property name="format" value="[ \t]+$"/>
+      <property name="illegalPattern" value="true"/>
+      <property name="message" value="Trailing whitespace"/>
+    </module>
   </module>
 </module>

--- a/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/ListMatcher.java
+++ b/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/ListMatcher.java
@@ -11,8 +11,8 @@ import static io.github.nik9000.mapmatcher.MapMatcher.describeEntryMissing;
 import static io.github.nik9000.mapmatcher.MapMatcher.describeEntryUnexepected;
 import static io.github.nik9000.mapmatcher.MapMatcher.describeEntryValue;
 import static io.github.nik9000.mapmatcher.MapMatcher.describeMatcher;
+import static io.github.nik9000.mapmatcher.MapMatcher.matcherFor;
 import static io.github.nik9000.mapmatcher.MapMatcher.maxKeyWidthForMatcher;
-import static org.hamcrest.Matchers.equalTo;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -34,6 +34,17 @@ public class ListMatcher extends TypeSafeMatcher<List<?>> {
     return new ListMatcher(emptyList());
   }
 
+  /**
+   * Create a {@linkplain ListMatcher} that matches a list.
+   */
+  public static ListMatcher matchesList(List<?> list) {
+    ListMatcher matcher = matchesList();
+    for (Object item : list) {
+      matcher = matcher.item(item);
+    }
+    return matcher;
+  }
+
   private final List<Matcher<?>> matchers;
 
   private ListMatcher(List<Matcher<?>> matchers) {
@@ -42,17 +53,22 @@ public class ListMatcher extends TypeSafeMatcher<List<?>> {
 
   /**
    * Expect a value.
+   * <p>
+   * Passing a {@link Matcher} to this method will function as though you
+   * passed it directly to {@link #item(Matcher)}.
    *
-   * @return a new {@link ListMatcher} that expects another item
+   * @return a new {@link ListMatcher} that expects all items this matcher
+   *         expected followed by the provided item
    */
   public ListMatcher item(Object value) {
-    return item(equalTo(value));
+    return item(matcherFor(value));
   }
 
   /**
    * Expect a {@link Matcher}.
    *
-   * @return a new {@link ListMatcher} that expects another item
+   * @return a new {@link ListMatcher} that expects all items this matcher
+   *         expected followed by the provided item
    */
   public ListMatcher item(Matcher<?> valueMatcher) {
     List<Matcher<?>> matchers = new ArrayList<>(this.matchers);

--- a/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/DocTest.java
+++ b/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/DocTest.java
@@ -44,7 +44,7 @@ public class DocTest {
   }
 
   @Test
-  public void errorMessageMatches() throws IOException {
+  public void explicitExample() throws IOException {
     try {
       // @formatter:off
       // CODESTART

--- a/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/ListMatcherTest.java
+++ b/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/ListMatcherTest.java
@@ -11,6 +11,7 @@ import static io.github.nik9000.mapmatcher.MapMatcher.matchesMap;
 import static io.github.nik9000.mapmatcher.MapMatcherTest.assertDescribeTo;
 import static io.github.nik9000.mapmatcher.MapMatcherTest.assertMismatch;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 
 import java.util.List;
@@ -79,6 +80,18 @@ class ListMatcherTest {
     mismatch.append("bar: expected <1> but was <2>\n");
     mismatch.append("1: <2>");
     assertMismatch(List.of(Map.of("bar", 2), 2),
+        matchesList().item(Map.of("bar", 1)).item(2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void subMapMatcher() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a list containing\n");
+    mismatch.append("0: a map containing\n");
+    mismatch.append("bar: expected <1> but was <2>\n");
+    mismatch.append("1: <2>");
+    assertMismatch(List.of(Map.of("bar", 2), 2),
         matchesList().item(matchesMap().entry("bar", 1)).item(2),
         equalTo(mismatch.toString()));
   }
@@ -91,7 +104,62 @@ class ListMatcherTest {
     mismatch.append("  0: expected <1> but was <2>\n");
     mismatch.append("1: <2>");
     assertMismatch(List.of(List.of(2), 2),
+        matchesList().item(List.of(1)).item(2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void subListMatcher() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a list containing\n");
+    mismatch.append("0: a list containing\n");
+    mismatch.append("  0: expected <1> but was <2>\n");
+    mismatch.append("1: <2>");
+    assertMismatch(List.of(List.of(2), 2),
         matchesList().item(matchesList().item(1)).item(2),
+        equalTo(mismatch.toString()));
+  }
+
+
+  @Test
+  void subMatcher() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a list containing\n");
+    mismatch.append("0: expected a numeric value within <0.5> of <1.0> but");
+    mismatch.append(" <2.0> differed by <0.5> more than delta <0.5>\n");
+    mismatch.append("1: <2>");
+    assertMismatch(List.of(2.0, 2),
+        matchesList().item(closeTo(1.0, 0.5)).item(2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void subMatcherAsValue() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a list containing\n");
+    mismatch.append("0: expected a numeric value within <0.5> of <1.0> but");
+    mismatch.append(" <2.0> differed by <0.5> more than delta <0.5>\n");
+    mismatch.append("1: <2>");
+    Object item0 = closeTo(1.0, 0.5);
+    assertMismatch(List.of(2.0, 2),
+        matchesList().item(item0).item(2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void provideList() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a list containing\n");
+    mismatch.append("0: a list containing\n");
+    mismatch.append("  0: <1>\n");
+    mismatch.append("1: a map containing\n");
+    mismatch.append("bar: expected <1> but was <2>\n");
+    mismatch.append("2: expected a numeric value within <0.5> of <1.0> but");
+    mismatch.append(" <2.0> differed by <0.5> more than delta <0.5>");
+
+    Object item0 = closeTo(1.0, 0.5);
+    assertMismatch(List.of(List.of(1), Map.of("bar", 2), 2.0),
+        matchesList(List.of(List.of(1), Map.of("bar", 1), closeTo(1.0, 0.5))),
         equalTo(mismatch.toString()));
   }
 

--- a/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/MapMatcherTest.java
+++ b/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/MapMatcherTest.java
@@ -140,6 +140,18 @@ class MapMatcherTest {
     mismatch.append("  bar: expected <1> but was <2>\n");
     mismatch.append("baz: <2>");
     assertMismatch(Map.of("foo", Map.of("bar", 2), "baz", 2),
+        matchesMap().entry("foo", Map.of("bar", 1)).entry("baz", 2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void subMapMatcher() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a map containing\n");
+    mismatch.append("foo: a map containing\n");
+    mismatch.append("  bar: expected <1> but was <2>\n");
+    mismatch.append("baz: <2>");
+    assertMismatch(Map.of("foo", Map.of("bar", 2), "baz", 2),
         matchesMap().entry("foo", matchesMap().entry("bar", 1)).entry("baz", 2),
         equalTo(mismatch.toString()));
   }
@@ -152,7 +164,67 @@ class MapMatcherTest {
     mismatch.append("    0: expected <1> but was <2>\n");
     mismatch.append("bar: <2>");
     assertMismatch(Map.of("foo", List.of(2), "bar", 2),
+        matchesMap().entry("foo", List.of(1)).entry("bar", 2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void subListMatcher() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a map containing\n");
+    mismatch.append("foo: a list containing\n");
+    mismatch.append("    0: expected <1> but was <2>\n");
+    mismatch.append("bar: <2>");
+    assertMismatch(Map.of("foo", List.of(2), "bar", 2),
         matchesMap().entry("foo", matchesList().item(1)).entry("bar", 2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void subMatcher() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a map containing\n");
+    mismatch.append("foo: expected a numeric value within <0.5> of <1.0> but ");
+    mismatch.append("<2.0> differed by <0.5> more than delta <0.5>\n");
+    mismatch.append("bar: <2>");
+    assertMismatch(Map.of("foo", 2.0, "bar", 2),
+        matchesMap().entry("foo", closeTo(1.0, .5)).entry("bar", 2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void subMatcherAsValue() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a map containing\n");
+    mismatch.append("foo: expected a numeric value within <0.5> of <1.0> but ");
+    mismatch.append("<2.0> differed by <0.5> more than delta <0.5>\n");
+    mismatch.append("bar: <2>");
+    Object foo = closeTo(1.0, .5);
+    assertMismatch(Map.of("foo", 2.0, "bar", 2),
+        matchesMap().entry("foo", foo).entry("bar", 2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void provideMap() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a map containing\n");
+    mismatch.append("foo: a list containing\n");
+    mismatch.append("    0: expected <1> but was <2>\n");
+    mismatch.append("bar: a map containing\n");
+    mismatch.append("    a: <2>\n");
+    mismatch.append("baz: expected a numeric value within <0.5> of <1.0> but ");
+    mismatch.append("<2.0> differed by <0.5> more than delta <0.5>");
+    /*
+     * Iteration order of the specification map gives the order of the
+     * error message so we use a LinkedHashMap to preserve our order.
+     */
+    Map<String, Object> spec = new LinkedHashMap<>();
+    spec.put("foo", List.of(1));
+    spec.put("bar", Map.of("a", 2));
+    spec.put("baz", closeTo(1.0, 0.5));
+    assertMismatch(Map.of("foo", List.of(2), "bar", Map.of("a", 2), "baz", 2.0),
+        matchesMap(spec),
         equalTo(mismatch.toString()));
   }
 


### PR DESCRIPTION
Modifies the public API to make us a little easier to use:
* Adds `matchesList(List)` that builds a matcher from an existing List
* Adds `matcherMap(Map)` that builds a matcher from an existing Map
* Handles the values in `entry(Object, Object)` and `item(Object)` with
  a litting more care, attempting to "do the right thing" based on the
  Object provided. If the value is a `Map` or `List` we'll use one of
  the new methods above to build a matcher for it, rather than
  `equalTo`. If the value is itself a matcher we'll just use it rather
  than building a matcher that is `equalTo` the matcher.

Now you can do stuff like:
```
matchList(List.of(1, 2, List.of(3, 4), closeTo(5.0, 0.0001)));
```

and it'll match `[1, 2, [3, 4], 5]`.