### PR TITLE
Better errors on empty

### DIFF
--- a/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/ListMatcher.java
+++ b/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/ListMatcher.java
@@ -98,11 +98,7 @@ public class ListMatcher extends TypeSafeMatcher<List<?>> {
   }
 
   void describeTo(int keyWidth, Description description) {
-    if (matchers.isEmpty()) {
-      description.appendText("an empty list");
-      return;
-    }
-    description.appendText("a list containing");
+    description.appendText(matchers.isEmpty() ? "an empty list" : "a list containing");
     int index = 0;
     for (Matcher<?> matcher : matchers) {
       describeMatcher(keyWidth, index++, matcher, description);
@@ -130,11 +126,7 @@ public class ListMatcher extends TypeSafeMatcher<List<?>> {
   }
 
   void describePotentialMismatch(int keyWidth, List<?> item, Description description) {
-    if (matchers.isEmpty()) {
-      description.appendText("an empty list");
-      return;
-    }
-    description.appendText("a list containing");
+    description.appendText(matchers.isEmpty() ? "an empty list" : "a list containing");
     int maxKeyWidth = Integer.toString(Math.max(item.size(), matchers.size())).length();
     String keyFormat = "%" + maxKeyWidth + "s";
 

--- a/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/MapMatcher.java
+++ b/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/MapMatcher.java
@@ -157,11 +157,7 @@ public class MapMatcher extends TypeSafeMatcher<Map<?, ?>> {
   }
 
   void describeTo(int keyWidth, Description description) {
-    if (matchers.isEmpty()) {
-      description.appendText("an empty map");
-      return;
-    }
-    description.appendText("a map containing");
+    description.appendText(matchers.isEmpty() ? "an empty map" : "a map containing");
     for (Map.Entry<?, Matcher<?>> e : matchers.entrySet()) {
       describeMatcher(keyWidth, e.getKey(), e.getValue(), description);
     }
@@ -211,11 +207,7 @@ public class MapMatcher extends TypeSafeMatcher<Map<?, ?>> {
   }
 
   void describePotentialMismatch(int keyWidth, Map<?, ?> item, Description description) {
-    if (matchers.isEmpty()) {
-      description.appendText("an empty map");
-      return;
-    }
-    description.appendText("a map containing");
+    description.appendText(matchers.isEmpty() ? "an empty map" : "a map containing");
     int maxKeyWidth = Stream.concat(matchers.keySet().stream(), item.keySet().stream())
         .mapToInt(k -> k.toString().length())
         .max()

--- a/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/ListMatcherTest.java
+++ b/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/ListMatcherTest.java
@@ -97,6 +97,18 @@ class ListMatcherTest {
   }
 
   @Test
+  void subEmptyMap() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a list containing\n");
+    mismatch.append("0: an empty map\n");
+    mismatch.append("bar: <unexpected> but was <2>\n");
+    mismatch.append("1: <2>");
+    assertMismatch(List.of(Map.of("bar", 2), 2),
+        matchesList().item(Map.of()).item(2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
   void subList() {
     StringBuilder mismatch = new StringBuilder();
     mismatch.append("a list containing\n");
@@ -120,6 +132,17 @@ class ListMatcherTest {
         equalTo(mismatch.toString()));
   }
 
+  @Test
+  void subEmptyList() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a list containing\n");
+    mismatch.append("0: an empty list\n");
+    mismatch.append("  0: <unexpected> but was <2>\n");
+    mismatch.append("1: <2>");
+    assertMismatch(List.of(List.of(2), 2),
+        matchesList().item(List.of()).item(2),
+        equalTo(mismatch.toString()));
+  }
 
   @Test
   void subMatcher() {

--- a/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/MapMatcherTest.java
+++ b/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/MapMatcherTest.java
@@ -157,6 +157,18 @@ class MapMatcherTest {
   }
 
   @Test
+  void subEmptyMap() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a map containing\n");
+    mismatch.append("foo: an empty map\n");
+    mismatch.append("  bar: <unexpected> but was <2>\n");
+    mismatch.append("baz: <2>");
+    assertMismatch(Map.of("foo", Map.of("bar", 2), "baz", 2),
+        matchesMap().entry("foo", Map.of()).entry("baz", 2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
   void subList() {
     StringBuilder mismatch = new StringBuilder();
     mismatch.append("a map containing\n");
@@ -177,6 +189,18 @@ class MapMatcherTest {
     mismatch.append("bar: <2>");
     assertMismatch(Map.of("foo", List.of(2), "bar", 2),
         matchesMap().entry("foo", matchesList().item(1)).entry("bar", 2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void subEmptyList() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a map containing\n");
+    mismatch.append("foo: an empty list\n");
+    mismatch.append("    0: <unexpected> but was <2>\n");
+    mismatch.append("bar: <2>");
+    assertMismatch(Map.of("foo", List.of(2), "bar", 2),
+        matchesMap().entry("foo", List.of()).entry("bar", 2),
         equalTo(mismatch.toString()));
   }
 


### PR DESCRIPTION
Improves the error messages when we expect an empty list of empty map
but don't receive one. Now we list what we *do* receive.