### PR TITLE
Handle nulls and improve errors on missing

### DIFF
--- a/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/ListMatcher.java
+++ b/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/ListMatcher.java
@@ -6,6 +6,7 @@
 package io.github.nik9000.mapmatcher;
 
 import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.nullValue;
 import static io.github.nik9000.mapmatcher.MapMatcher.describeEntry;
 import static io.github.nik9000.mapmatcher.MapMatcher.describeEntryMissing;
 import static io.github.nik9000.mapmatcher.MapMatcher.describeEntryUnexepected;
@@ -71,6 +72,9 @@ public class ListMatcher extends TypeSafeMatcher<List<?>> {
    *         expected followed by the provided item
    */
   public ListMatcher item(Matcher<?> valueMatcher) {
+    if (valueMatcher == null) {
+      valueMatcher = nullValue();
+    }
     List<Matcher<?>> matchers = new ArrayList<>(this.matchers);
     matchers.add(valueMatcher);
     return new ListMatcher(matchers);

--- a/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/MapMatcher.java
+++ b/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/MapMatcher.java
@@ -8,6 +8,7 @@ package io.github.nik9000.mapmatcher;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -114,6 +115,9 @@ public class MapMatcher extends TypeSafeMatcher<Map<?, ?>> {
    * @return a new {@link MapMatcher} that expects another entry
    */
   public MapMatcher entry(Object key, Matcher<?> valueMatcher) {
+    if (valueMatcher == null) {
+      valueMatcher = nullValue();
+    }
     Map<Object, Matcher<?>> matchers = new LinkedHashMap<>(this.matchers);
     Matcher<?> old = matchers.put(key, valueMatcher);
     if (old != null) {
@@ -239,6 +243,9 @@ public class MapMatcher extends TypeSafeMatcher<Map<?, ?>> {
    * for the public API methods that take {@linkplain Object}.
    */
   static Matcher<?> matcherFor(Object value) {
+    if (value == null) {
+      return nullValue();
+    }
     if (value instanceof List) {
       return ListMatcher.matchesList((List<?>) value);
     }
@@ -257,7 +264,18 @@ public class MapMatcher extends TypeSafeMatcher<Map<?, ?>> {
   }
 
   static void describeEntryMissing(Matcher<?> matcher, Description description) {
-    description.appendText("expected ").appendDescriptionOf(matcher);
+    description.appendText("expected ");
+    /*
+     * Use a short description for multi-line matchers so the "but was <missing>"
+     * bit of the erro is more prominent. It's the more important part.
+     */
+    if (matcher instanceof MapMatcher) {
+      description.appendText("a map");
+    } else if (matcher instanceof ListMatcher) {
+      description.appendText("a list");
+    } else {
+      description.appendDescriptionOf(matcher);
+    }
     description.appendText(" but was <missing>");
   }
 


### PR DESCRIPTION
This adds support for `matchesList().item(null)` to match null list
items and `matchesMap().entry("key", null)` to match null list values.
It also improves the error messages when a key is missing.