### PR TITLE
Fix NoSuchElementException on empty sub maps

### DIFF
--- a/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/MapMatcher.java
+++ b/mapmatcher/src/main/java/io/github/nik9000/mapmatcher/MapMatcher.java
@@ -215,7 +215,7 @@ public class MapMatcher extends TypeSafeMatcher<Map<?, ?>> {
     int maxKeyWidth = Stream.concat(matchers.keySet().stream(), item.keySet().stream())
         .mapToInt(k -> k.toString().length())
         .max()
-        .getAsInt();
+        .orElse(keyWidth);
     String keyFormat = "%" + maxKeyWidth + "s";
 
     for (Map.Entry<Object, Matcher<?>> e : matchers.entrySet()) {

--- a/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/MapMatcherTest.java
+++ b/mapmatcher/src/test/java/io/github/nik9000/mapmatcher/MapMatcherTest.java
@@ -186,7 +186,7 @@ class MapMatcherTest {
   }
 
   @Test
-  void subEmptyMap() {
+  void subEmptyExpectedMap() {
     StringBuilder mismatch = new StringBuilder();
     mismatch.append("a map containing\n");
     mismatch.append("foo: an empty map\n");
@@ -194,6 +194,29 @@ class MapMatcherTest {
     mismatch.append("baz: <2>");
     assertMismatch(Map.of("foo", Map.of("bar", 2), "baz", 2),
         matchesMap().entry("foo", Map.of()).entry("baz", 2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void subEmptyActualMap() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a map containing\n");
+    mismatch.append("foo: a map containing\n");
+    mismatch.append("  bar: expected <2> but was <missing>\n");
+    mismatch.append("baz: <2>");
+    assertMismatch(Map.of("foo", Map.of(), "baz", 2),
+        matchesMap().entry("foo", Map.of("bar", 2)).entry("baz", 2),
+        equalTo(mismatch.toString()));
+  }
+
+  @Test
+  void subEmptyActualAndExpectedMap() {
+    StringBuilder mismatch = new StringBuilder();
+    mismatch.append("a map containing\n");
+    mismatch.append("foo: an empty map\n");
+    mismatch.append("bar: expected <2> but was <1>");
+    assertMismatch(Map.of("foo", Map.of(), "bar", 1),
+        matchesMap().entry("foo", Map.of()).entry("bar", 2),
         equalTo(mismatch.toString()));
   }
 


### PR DESCRIPTION
If the expected and actual maps both contained a sub-map that was
empty (in both) the width calculation would throw a
NoSuchElementException